### PR TITLE
CDM-214: Match job_info fields to CTS job fields

### DIFF
--- a/cdmeventimporters/checkm2.py
+++ b/cdmeventimporters/checkm2.py
@@ -48,8 +48,8 @@ def run_import(get_spark, job_info: dict[str, Any], override_metadata: dict[str,
     logr = logging.getLogger(__name__)
 
     # TODO DOCS document job_info structure
-    job_id = job_info["job_id"]
-    output_files = [f["file"] for f in job_info["output"] if f["file"].endswith(_QUAL_REP)]
+    job_id = job_info["id"]
+    output_files = [f["file"] for f in job_info["outputs"] if f["file"].endswith(_QUAL_REP)]
     logr.info(f"Importing {len(output_files)} CheckM2 quality reports from CTS job {job_id}")
     
     meta = utilities.get_importer_metadata((Path(__file__) / ".." / "checkm2.yaml").resolve())

--- a/test/checkm2_test.py
+++ b/test/checkm2_test.py
@@ -83,8 +83,8 @@ def test_checkm2_success_2_files():
     file1 = f"{bucket}/checkm2/sub1/quality_report.tsv"
     file2 = f"{bucket}/checkm2/sub2/quality_report.tsv"
     job_info = {
-        "job_id": "tstjob",
-        "output": [
+        "id": "tstjob",
+        "outputs": [
             {
                 "file": file1,
                 "crc64nvme": "fake",


### PR DESCRIPTION
Where possible, anyway. Easier for users if the job_info structure has the same keys as the CTS job model.