### PR TITLE
CDM-303: Update for governance compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The data structure provided in the 2nd argument to `run_import` is a dictionary:
         },
         ...
     ],
+    "namespace_prefix": <the prefix to use for any Spark SQL namespaces>,
     "image": <the image name of CTS Docker image that was run as part of the job>,
     "image_digest": <the digest of the image>,
     "input_file_count": <the number of input files for the job>,
@@ -57,8 +58,9 @@ The data structure provided in the 2nd argument to `run_import` is a dictionary:
 }
 ```
 
-For a simple importer probably only the `'id` and `outputs` fields are necessary. The job ID
-should be included in the deltatable for data lineage tracking purposes.
+For a simple importer probably only the `id`, `outputs`, and `namespace_prefix`
+fields are necessary. The job ID should be included in the deltatable for data lineage
+tracking purposes. Any SQL namespaces the importer uses must be prefixed with `namespace_prefix`.
 
 #### YAML file structure
 
@@ -92,7 +94,7 @@ Note that multiple YAML files cannot reference the same Docker image.
   else for processing.
 * Do not assume that the event will only occur once. In the case of upstream failures, an
   event may be provided to the importer more than once - the importer should take this into
-  account and prevent adding duplicate data to the database. the CheckM2 example code shows
+  account and prevent adding duplicate data to the database. The CheckM2 example code shows
   how to handle this.
 * The same importer is called for all versions of a Docker image. If data needs to be processed
   differently for different versions of the image, it is the importer's responsibility to do so.

--- a/cdmeventimporters/checkm2.py
+++ b/cdmeventimporters/checkm2.py
@@ -2,16 +2,50 @@
 Importer for Checkm2 quality metrics.
 """
 
-from delta.tables import DeltaTable
 import logging
+from pyspark.sql import SparkSession
 from pyspark.sql.functions import col, lit
+from pyspark.sql.types import StructType, StructField, StringType, FloatType, IntegerType
+from pyspark.sql.utils import AnalysisException
 from typing import Any
 
 from cdmeventimporters import utilities
 
 
+CTS_JOB_ID = "cts_job_id"
+CHECKM2_NAME_FIELD = "Name"
 _QUAL_REP = "quality_report.tsv"
-_JOB_ID_COL = "cts_job_id"
+
+
+CHECKM2_DB_SCHEMA = StructType([
+    StructField(CHECKM2_NAME_FIELD, StringType()),
+    StructField(CTS_JOB_ID, StringType()),
+    StructField("Completeness", FloatType()),
+    StructField("Contamination", FloatType()),
+    StructField("Completeness_Model_Used", StringType()),
+    StructField("Translation_Table_Used", IntegerType()),
+    StructField("Coding_Density", FloatType()),
+    StructField("Contig_N50", IntegerType()),
+    StructField("Average_Gene_Length", FloatType()),
+    StructField("Genome_Size", IntegerType()),
+    StructField("GC_Content", FloatType()),
+    StructField("Total_Coding_Sequences", IntegerType()),
+    StructField("Total_Contigs", IntegerType()),
+    StructField("Max_Contig_Length", IntegerType()),
+    StructField("Additional_Notes", StringType(), True),  # allow nulls
+])
+
+
+def _ensure_table(spark: SparkSession, logr: logging.Logger, full_tablename: str):
+    namespace = full_tablename.split(".")[0]  # assumes just namespace and table
+    spark.sql(f"CREATE DATABASE IF NOT EXISTS {namespace}")
+    try:
+        spark.sql(f"DESCRIBE TABLE {full_tablename}")
+        # table exists, all done
+    except AnalysisException:
+        logr.info(f"Creating new Delta table {full_tablename}")
+        empty_df = spark.createDataFrame([], CHECKM2_DB_SCHEMA)
+        empty_df.write.format("delta").option("compression", "snappy").saveAsTable(full_tablename)
 
 
 def run_import(get_spark, job_info: dict[str, Any], metadata: dict[str, Any]):
@@ -58,23 +92,19 @@ def run_import(get_spark, job_info: dict[str, Any], metadata: dict[str, Any]):
         raise ValueError(
             "Expected a 'deltatable' key in the importer metadata with the db table as the value"
         )
+    deltaname = job_info["namespace_prefix"] + deltaname
     
     # For now just using 1 core per executor, this is mostly IO. If we want to be able
     # to set cores probably need output file size info
     spark = get_spark()
     # TODO CODE could probably add some helper functions for some of this
-    delta_schema = DeltaTable.forName(spark, deltaname).toDF().schema
-    schema_fields = {f.name for f in delta_schema}
-    if _JOB_ID_COL not in schema_fields:
-        raise ValueError(
-            f"The expected job id column, {_JOB_ID_COL}, is not in the configured "
-            + f"CheckM2 deltatable, {deltaname}"
-    )
+    _ensure_table(spark, logr, deltaname)
+    schema_fields = {f.name for f in CHECKM2_DB_SCHEMA}
     df = spark.read.option(
         "header", True
         ).option("sep", "\t"
         ).csv([f"s3a://{f}" for f in output_files]
-        ).withColumn(_JOB_ID_COL, lit(job_id)
+        ).withColumn(CTS_JOB_ID, lit(job_id)
     )
     got_fields = set(df.columns)
     if schema_fields - got_fields:
@@ -84,7 +114,7 @@ def run_import(get_spark, job_info: dict[str, Any], metadata: dict[str, Any]):
     # coerce schema to match deltatable, needs to happen AFTER the column existence check
     columns = [
         (col(field.name).cast(field.dataType)).alias(field.name)
-        for field in delta_schema
+        for field in CHECKM2_DB_SCHEMA
     ]
     df = df.select(*columns)
     

--- a/cdmeventimporters/checkm2.yaml
+++ b/cdmeventimporters/checkm2.yaml
@@ -7,5 +7,6 @@ py_module: cdmeventimporters.checkm2
 image:  ghcr.io/kbasetest/cdm_checkm2
 # Metadata for the importer.
 importer_meta:
-    # The table where checkm2 data should be stored.
-    deltatable: berdl_cdm.checkm2
+    # The table where checkm2 data should be stored
+    # Does NOT include the namespace prefix for the user.
+    deltatable: autoimport.checkm2

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -124,13 +124,13 @@ services:
       IMP_SPARK_MASTER_URL: spark://spark-master:7077
       IMP_SPARK_DRIVER_HOST: test-container
       IMP_MINIO_IMPORTER_RAW_BUCKET: cts-output
+      IMP_SQL_WAREHOUSE_PREFIX: s3a://cdm-lake/user_warehouse/
 
       # variables used by the base image
       POSTGRES_USER: hive
       POSTGRES_PASSWORD: hivepassword
       POSTGRES_DB: hive
       POSTGRES_URL: postgres:5432
-      DELTALAKE_WAREHOUSE_DIR: s3a://cdm-lake/warehouse
       # Importers should not implicitly create tables, but hive won't start without this
       DATANUCLEUS_AUTO_CREATE_TABLES: true
 

--- a/test/checkm2_test.py
+++ b/test/checkm2_test.py
@@ -1,8 +1,16 @@
 # TODO CHECKM2 add more test cases, failing tests etc.
 
-from pyspark.sql.types import StructType, StructField, StringType, FloatType, IntegerType, Row
+from pyspark.sql.types import Row
+import pytest
+import traceback
+from typing import Any
 
-from cdmeventimporters import checkm2
+from cdmeventimporters.checkm2 import (
+    run_import,
+    CHECKM2_DB_SCHEMA,
+    CHECKM2_NAME_FIELD,
+    CTS_JOB_ID
+)
 from utils.misc import (
     assert_pyspark_rows_almost_equal,
     get_CTS_output_bucket,
@@ -13,30 +21,7 @@ from utils.misc import (
 from utils.spark import spark_session, SparkProvider
 
 
-_CTS_JOB_ID = "cts_job_id"
-_CHECKM2_NAME_FIELD = "Name"
-
-
-_CHECKM2_DB_SCHEMA = StructType([
-    StructField(_CHECKM2_NAME_FIELD, StringType()),
-    StructField(_CTS_JOB_ID, StringType()),
-    StructField("Completeness", FloatType()),
-    StructField("Contamination", FloatType()),
-    StructField("Completeness_Model_Used", StringType()),
-    StructField("Translation_Table_Used", IntegerType()),
-    StructField("Coding_Density", FloatType()),
-    StructField("Contig_N50", IntegerType()),
-    StructField("Average_Gene_Length", FloatType()),
-    StructField("Genome_Size", IntegerType()),
-    StructField("GC_Content", FloatType()),
-    StructField("Total_Coding_Sequences", IntegerType()),
-    StructField("Total_Contigs", IntegerType()),
-    StructField("Max_Contig_Length", IntegerType()),
-    StructField("Additional_Notes", StringType(), True),  # allow nulls
-])
-
-
-_CHECKM2_FILE_HEADERS = [field.name for field in _CHECKM2_DB_SCHEMA if field.name != _CTS_JOB_ID]
+_CHECKM2_FILE_HEADERS = [field.name for field in CHECKM2_DB_SCHEMA if field.name != CTS_JOB_ID]
 
 
 _CHECKM2_DB_INIT_DATA =  [
@@ -56,11 +41,17 @@ _CHECKM2_FILE2_DATA =  [
 ]
 
 
-_CHECKM2_EXPECTED_DATA = [
-    ("GCA_bsubtilis", "tstjob", .91, .27, "mod", 9, .49, 150, .50, 46, .93, 36, 5, 16, "whoo"),
-    ("GCA_ecoli", "tstjob", .90, .26, "model4", 8, .48, 149, .49, 45, .92, 35, 4, 15, None),
+_CHECKM2_EXPECTED_DATA_FILE1 = [
+    ("GCA_ecoli", "tstjob1", .90, .26, "model4", 8, .48, 149, .49, 45, .92, 35, 4, 15, None),
+    ("GCA_replace", "tstjob1", .89, .25, "model3", 7, .47, 148, .48, 44, .91, 34, 3, 14, "hello"),
+]
+
+
+_CHECKM2_EXPECTED_DATA_FULL = [
+    ("GCA_bsubtilis", "tstjob2", .91, .27, "mod", 9, .49, 150, .50, 46, .93, 36, 5, 16, "whoo"),
+    ("GCA_ecoli", "tstjob2", .90, .26, "model4", 8, .48, 149, .49, 45, .92, 35, 4, 15, None),
     ("GCA_keep", "old_job2", .88, .24, "model2", 6, .46, 147, .47, 43, .90, 33, 2, 13, "Lovely"),
-    ("GCA_replace", "tstjob", .89, .25, "model3", 7, .47, 148, .48, 44, .91, 34, 3, 14, "hello"),
+    ("GCA_replace", "tstjob2", .89, .25, "model3", 7, .47, 148, .48, 44, .91, 34, 3, 14, "hello"),
 ]
 
 
@@ -69,28 +60,77 @@ _CHECKM2_EXPECTED_DATA = [
 set_up_basic_logging(force=False)
 
 
-def expected_data_to_rows():
+def expected_data_to_rows(expected: list[tuple[Any, ...]]):
     ret = []
-    for r in _CHECKM2_EXPECTED_DATA:
-        ret.append(Row(**{f: d for f, d in zip([field.name for field in _CHECKM2_DB_SCHEMA], r)}))
+    for r in expected:
+        ret.append(Row(**{f: d for f, d in zip([field.name for field in CHECKM2_DB_SCHEMA], r)}))
     return ret
 
 
-def test_checkm2_success_2_files():
-    # This test is slooow. Probably better to make a fixture that sets everything up and 
-    # reuse it for other tests.
+@pytest.fixture(scope="module")
+def minio_files():
     bucket = get_CTS_output_bucket()
     file1 = f"{bucket}/checkm2/sub1/quality_report.tsv"
     file2 = f"{bucket}/checkm2/sub2/quality_report.tsv"
+    s3cli = get_s3_client()
+    write_tsv_to_s3(s3cli, file1, _CHECKM2_FILE_HEADERS, _CHECKM2_FILE1_DATA)
+    write_tsv_to_s3(s3cli, file2, _CHECKM2_FILE_HEADERS, _CHECKM2_FILE2_DATA)
+    return file1, file2
+
+
+def test_checkm2_success_1_file_new_table(minio_files):
+    # This test is slooow. Probably better to make a fixture that sets everything up and 
+    # reuse it for other tests.
+    user = "someuser"
+    namespace_prefix = f"u_{user}__"
+    file1 = minio_files[0]
     job_info = {
-        "id": "tstjob",
+        "id": "tstjob1",
+        "namespace_prefix": namespace_prefix,
+        "outputs": [{"file": file1, "crc64nvme": "fake"}]
+    }
+    sparkprov = None
+    try:
+        # run the importer
+        sparkprov = SparkProvider("test_checkm2", user)
+        run_import(sparkprov, job_info, {"deltatable": "checkm2_test.checkm2_single"})
+        
+        # might as well keep using the importer spark session. If needed make yet another
+        # new session
+        spark = sparkprov.spark
+        # check the results
+        res_df = spark.sql(f"SELECT * FROM {namespace_prefix}checkm2_test.checkm2_single")
+        actual_data = res_df.orderBy(CHECKM2_NAME_FIELD).collect()
+        assert_pyspark_rows_almost_equal(
+            actual_data, expected_data_to_rows(_CHECKM2_EXPECTED_DATA_FILE1)
+        )
+    except Exception:
+        traceback.print_exc()  # can get shadowed by exception in the finally block
+        raise
+    finally:
+        if sparkprov:
+            sparkprov.stop()
+        spark_clean = spark_session("test_checkm2_helper", user)
+        spark_clean.sql(f"DROP DATABASE IF EXISTS {namespace_prefix}checkm2_test CASCADE")
+        spark_clean.stop()
+
+
+def test_checkm2_success_2_files_existing_table(minio_files):
+    # This test is slooow. Probably better to make a fixture that sets everything up and 
+    # reuse it for other tests.
+    user = "testuser"
+    namespace_prefix = f"u_{user}__"
+    file1, file2 = minio_files
+    job_info = {
+        "id": "tstjob2",
+        "namespace_prefix": namespace_prefix,
         "outputs": [
             {
                 "file": file1,
                 "crc64nvme": "fake",
             },
             {
-                "file": f"{bucket}/checkm2/sub1/other_checkm_file",
+                "file": f"{get_CTS_output_bucket()}/checkm2/sub1/other_checkm_file",
                 "crc64nvme": "fake",
             },
             {
@@ -99,37 +139,39 @@ def test_checkm2_success_2_files():
             },
         ]
     }
-    spark_setup = spark_session("test_checkm2_startup")
+    spark_setup = spark_session("test_checkm2_startup", user)
     sparkprov = None
     try:
-        spark_setup.sql("CREATE DATABASE IF NOT EXISTS checkm2_test")
-        df = spark_setup.createDataFrame(_CHECKM2_DB_INIT_DATA, schema=_CHECKM2_DB_SCHEMA)
+        spark_setup.sql(f"CREATE DATABASE IF NOT EXISTS {namespace_prefix}checkm2_test")
+        df = spark_setup.createDataFrame(_CHECKM2_DB_INIT_DATA, schema=CHECKM2_DB_SCHEMA)
         df.write.mode(
             "overwrite"
             ).option("compression", "snappy"
             ).format("delta"
-            ).saveAsTable("checkm2_test.checkm2"
+            ).saveAsTable(f"{namespace_prefix}checkm2_test.checkm2"
         )
         spark_setup.stop()
-        s3cli = get_s3_client()
-        write_tsv_to_s3(s3cli, file1, _CHECKM2_FILE_HEADERS, _CHECKM2_FILE1_DATA)
-        write_tsv_to_s3(s3cli, file2, _CHECKM2_FILE_HEADERS, _CHECKM2_FILE2_DATA)
 
         # run the importer
-        sparkprov = SparkProvider("test_checkm2")
-        checkm2.run_import(sparkprov, job_info, {"deltatable": "checkm2_test.checkm2"})
+        sparkprov = SparkProvider("test_checkm2", user)
+        run_import(sparkprov, job_info, {"deltatable": "checkm2_test.checkm2"})
         
         # might as well keep using the importer spark session. If needed make yet another
         # new session
         spark = sparkprov.spark
         # check the results
-        res_df = spark.sql("SELECT * FROM checkm2_test.checkm2")
-        actual_data = res_df.orderBy(_CHECKM2_NAME_FIELD).collect()
-        assert_pyspark_rows_almost_equal(actual_data, expected_data_to_rows())
+        res_df = spark.sql(f"SELECT * FROM {namespace_prefix}checkm2_test.checkm2")
+        actual_data = res_df.orderBy(CHECKM2_NAME_FIELD).collect()
+        assert_pyspark_rows_almost_equal(
+            actual_data, expected_data_to_rows(_CHECKM2_EXPECTED_DATA_FULL)
+        )
+    except Exception:
+        traceback.print_exc()  # can get shadowed by exception in the finally block
+        raise
     finally:
         spark_setup.stop()
         if sparkprov:
             sparkprov.stop()
-        spark_clean = spark_session("test_checkm2_helper")
-        spark_clean.sql("DROP DATABASE IF EXISTS checkm2_test CASCADE")
+        spark_clean = spark_session("test_checkm2_helper", user)
+        spark_clean.sql(f"DROP DATABASE IF EXISTS {namespace_prefix}checkm2_test CASCADE")
         spark_clean.stop()


### PR DESCRIPTION
* The event handler will be updated to include the user namespace prefix in the job_info passed to the importer. That change is reflected here
* Updated the importer to create tables when needed, since there's no longer any guarantee they'll exist
* Also updated to use a similar warehouse path as the governance service, although from the perspective of the importer this is invisible