### PR TITLE
Add MMseqs2 easy-cluster importer

### DIFF
--- a/cdmeventimporters/mmseqs2.py
+++ b/cdmeventimporters/mmseqs2.py
@@ -3,10 +3,11 @@ Importer for MMseqs2 easy-cluster results.
 """
 
 import logging
+from typing import Any
+
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import col, lit
-from pyspark.sql.types import StructType, StructField, StringType
-from typing import Any
+from pyspark.sql.types import StringType, StructField, StructType
 
 from cdmeventimporters import utilities
 
@@ -22,12 +23,12 @@ MMSEQS2_CLUSTER_SCHEMA = StructType([
 
 
 def _ensure_table(spark: SparkSession, logr: logging.Logger, full_tablename: str):
-    namespace = full_tablename.split(".")[0]
-    spark.sql(f"CREATE DATABASE IF NOT EXISTS {namespace}")
+    namespace = full_tablename.rsplit(".", 1)[0]
+    spark.sql(f"CREATE NAMESPACE IF NOT EXISTS {namespace}")
     if not spark.catalog.tableExists(full_tablename):
-        logr.info(f"Creating new Delta table {full_tablename}")
+        logr.info(f"Creating new Iceberg table {full_tablename}")
         empty_df = spark.createDataFrame([], MMSEQS2_CLUSTER_SCHEMA)
-        empty_df.write.format("delta").option("compression", "snappy").saveAsTable(full_tablename)
+        empty_df.writeTo(full_tablename).using("iceberg").create()
 
 
 def run_import(get_spark, job_info: dict[str, Any], metadata: dict[str, Any]):
@@ -35,17 +36,19 @@ def run_import(get_spark, job_info: dict[str, Any], metadata: dict[str, Any]):
     Run the MMseqs2 easy-cluster import.
 
     Reads cluster_results_cluster.tsv (no header, columns: representative, member)
-    and writes to a Delta table with the cts_job_id appended.
+    and writes to an Iceberg table with the cts_job_id appended.
 
     Assumptions:
         * The cluster TSV has no header and two tab-separated columns.
-        * Each (representative, member, cts_job_id) triple is unique — duplicate events
+        * Each (representative, member, cts_job_id) triple is unique - duplicate events
           from reprocessing are safe due to the merge condition.
         * Results from different jobs are kept separately (cts_job_id is part of the key).
 
-    get_spark - a function to get a spark session.
-    job_info - information about the completed CTS job.
-    metadata - importer metadata from the YAML config (must include 'deltatable').
+    get_spark - a function to get a spark session. Has a single keyword argument,
+        executor_cores, that sets the cores per spark executor for the job. Defaults to 1.
+    job_info - information about the completed CTS job, in particular the job ID and
+        output files.
+    metadata - importer metadata from the YAML config (must include 'table').
     """
     logr = logging.getLogger(__name__)
 
@@ -55,15 +58,16 @@ def run_import(get_spark, job_info: dict[str, Any], metadata: dict[str, Any]):
         raise ValueError("No MMseqs2 cluster TSV files found in job outputs")
     logr.info(f"Importing {len(output_files)} MMseqs2 cluster file(s) from CTS job {job_id}")
 
-    deltaname = metadata.get("deltatable")
-    if not deltaname:
+    tablename = metadata.get("table")
+    if not tablename:
         raise ValueError(
-            "Expected a 'deltatable' key in the importer metadata with the db table as the value"
+            "Expected a 'table' key in the importer metadata with the namespace.table as the value"
         )
-    deltaname = job_info["namespace_prefix"] + deltaname
+    # The Spark session is wired to the user's Iceberg catalog as the default catalog,
+    # so a `<namespace>.<table>` reference resolves into that catalog automatically.
 
     spark = get_spark()
-    _ensure_table(spark, logr, deltaname)
+    _ensure_table(spark, logr, tablename)
 
     df = spark.read.option("header", False).option("sep", "\t").csv(
         [f"s3a://{f}" for f in output_files]
@@ -77,12 +81,12 @@ def run_import(get_spark, job_info: dict[str, Any], metadata: dict[str, Any]):
 
     # Deduplication key includes cts_job_id so results from different jobs coexist,
     # but reprocessed events for the same job don't insert duplicate rows.
-    utilities.merge_spark_df_to_deltatable(
+    utilities.merge_spark_df_to_table(
         spark,
         df,
-        deltaname,
-        "target.representative == source.representative "
-        "AND target.member == source.member "
-        "AND target.cts_job_id == source.cts_job_id",
+        tablename,
+        "target.representative = source.representative "
+        "AND target.member = source.member "
+        "AND target.cts_job_id = source.cts_job_id",
         update=False,
     )

--- a/cdmeventimporters/mmseqs2.py
+++ b/cdmeventimporters/mmseqs2.py
@@ -1,0 +1,88 @@
+"""
+Importer for MMseqs2 easy-cluster results.
+"""
+
+import logging
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import col, lit
+from pyspark.sql.types import StructType, StructField, StringType
+from typing import Any
+
+from cdmeventimporters import utilities
+
+
+CTS_JOB_ID = "cts_job_id"
+_CLUSTER_TSV = "cluster_results_cluster.tsv"
+
+MMSEQS2_CLUSTER_SCHEMA = StructType([
+    StructField("representative", StringType()),
+    StructField("member", StringType()),
+    StructField(CTS_JOB_ID, StringType()),
+])
+
+
+def _ensure_table(spark: SparkSession, logr: logging.Logger, full_tablename: str):
+    namespace = full_tablename.split(".")[0]
+    spark.sql(f"CREATE DATABASE IF NOT EXISTS {namespace}")
+    if not spark.catalog.tableExists(full_tablename):
+        logr.info(f"Creating new Delta table {full_tablename}")
+        empty_df = spark.createDataFrame([], MMSEQS2_CLUSTER_SCHEMA)
+        empty_df.write.format("delta").option("compression", "snappy").saveAsTable(full_tablename)
+
+
+def run_import(get_spark, job_info: dict[str, Any], metadata: dict[str, Any]):
+    """
+    Run the MMseqs2 easy-cluster import.
+
+    Reads cluster_results_cluster.tsv (no header, columns: representative, member)
+    and writes to a Delta table with the cts_job_id appended.
+
+    Assumptions:
+        * The cluster TSV has no header and two tab-separated columns.
+        * Each (representative, member, cts_job_id) triple is unique — duplicate events
+          from reprocessing are safe due to the merge condition.
+        * Results from different jobs are kept separately (cts_job_id is part of the key).
+
+    get_spark - a function to get a spark session.
+    job_info - information about the completed CTS job.
+    metadata - importer metadata from the YAML config (must include 'deltatable').
+    """
+    logr = logging.getLogger(__name__)
+
+    job_id = job_info["id"]
+    output_files = [f["file"] for f in job_info["outputs"] if f["file"].endswith(_CLUSTER_TSV)]
+    if not output_files:
+        raise ValueError("No MMseqs2 cluster TSV files found in job outputs")
+    logr.info(f"Importing {len(output_files)} MMseqs2 cluster file(s) from CTS job {job_id}")
+
+    deltaname = metadata.get("deltatable")
+    if not deltaname:
+        raise ValueError(
+            "Expected a 'deltatable' key in the importer metadata with the db table as the value"
+        )
+    deltaname = job_info["namespace_prefix"] + deltaname
+
+    spark = get_spark()
+    _ensure_table(spark, logr, deltaname)
+
+    df = spark.read.option("header", False).option("sep", "\t").csv(
+        [f"s3a://{f}" for f in output_files]
+    ).toDF("representative", "member").withColumn(CTS_JOB_ID, lit(job_id))
+
+    columns = [
+        col(field.name).cast(field.dataType).alias(field.name)
+        for field in MMSEQS2_CLUSTER_SCHEMA
+    ]
+    df = df.select(*columns)
+
+    # Deduplication key includes cts_job_id so results from different jobs coexist,
+    # but reprocessed events for the same job don't insert duplicate rows.
+    utilities.merge_spark_df_to_deltatable(
+        spark,
+        df,
+        deltaname,
+        "target.representative == source.representative "
+        "AND target.member == source.member "
+        "AND target.cts_job_id == source.cts_job_id",
+        update=False,
+    )

--- a/cdmeventimporters/mmseqs2.yaml
+++ b/cdmeventimporters/mmseqs2.yaml
@@ -7,6 +7,7 @@ py_module: cdmeventimporters.mmseqs2
 image: ghcr.io/kbaseincubator/cdm_mmseqs2
 # Metadata for the importer.
 importer_meta:
-    # The table where mmseqs2 cluster data should be stored.
-    # Does NOT include the namespace prefix for the user.
-    deltatable: autoimport.mmseqs2_clusters
+    # The table where mmseqs2 cluster data should be stored, in `<namespace>.<table>` format.
+    # The Spark session resolves this against the user's Iceberg catalog (the default
+    # catalog `my`), so no per-user prefix is required.
+    table: autoimport.mmseqs2_clusters

--- a/cdmeventimporters/mmseqs2.yaml
+++ b/cdmeventimporters/mmseqs2.yaml
@@ -1,0 +1,12 @@
+# The name of the importer. Informational purposes only.
+name: mmseqs2
+# The location of the importer module containing the `run_import` method.
+py_module: cdmeventimporters.mmseqs2
+# The image associated with the importer. This importer will run when a CTS job completes
+# with this image.
+image: ghcr.io/kbaseincubator/cdm_mmseqs2
+# Metadata for the importer.
+importer_meta:
+    # The table where mmseqs2 cluster data should be stored.
+    # Does NOT include the namespace prefix for the user.
+    deltatable: autoimport.mmseqs2_clusters

--- a/test/mmseqs2_test.py
+++ b/test/mmseqs2_test.py
@@ -1,0 +1,173 @@
+import pytest
+import traceback
+from pyspark.sql.types import Row
+
+from cdmeventimporters.mmseqs2 import (
+    run_import,
+    MMSEQS2_CLUSTER_SCHEMA,
+    CTS_JOB_ID,
+)
+from utils.misc import (
+    assert_pyspark_rows_almost_equal,
+    get_CTS_output_bucket,
+    get_s3_client,
+    set_up_basic_logging,
+    write_tsv_to_s3,
+)
+from utils.spark import spark_session, SparkProvider
+
+
+_CLUSTER_HEADERS = ["representative", "member"]
+
+# Initial table state (pre-existing rows from an older job)
+_DB_INIT_DATA = [
+    ("seq_keep", "seq_keep", "old_job"),
+]
+
+# File 1: two cluster memberships
+_FILE1_DATA = [
+    ("seq_A", "seq_A"),
+    ("seq_A", "seq_B"),
+]
+
+# File 2: one cluster membership
+_FILE2_DATA = [
+    ("seq_C", "seq_C"),
+]
+
+# Expected after importing file1 into a fresh table
+_EXPECTED_FILE1 = [
+    ("seq_A", "seq_A", "tstjob1"),
+    ("seq_A", "seq_B", "tstjob1"),
+]
+
+# Expected after importing both files into a table that already has _DB_INIT_DATA
+_EXPECTED_FULL = [
+    ("seq_A", "seq_A", "tstjob2"),
+    ("seq_A", "seq_B", "tstjob2"),
+    ("seq_C", "seq_C", "tstjob2"),
+    ("seq_keep", "seq_keep", "old_job"),
+]
+
+
+set_up_basic_logging(force=False)
+
+
+def _rows(data):
+    fields = [f.name for f in MMSEQS2_CLUSTER_SCHEMA]
+    return [Row(**dict(zip(fields, r))) for r in data]
+
+
+@pytest.fixture(scope="module")
+def minio_files():
+    bucket = get_CTS_output_bucket()
+    file1 = f"{bucket}/mmseqs2/sub1/cluster_results_cluster.tsv"
+    file2 = f"{bucket}/mmseqs2/sub2/cluster_results_cluster.tsv"
+    s3cli = get_s3_client()
+    write_tsv_to_s3(s3cli, file1, _CLUSTER_HEADERS, _FILE1_DATA)
+    write_tsv_to_s3(s3cli, file2, _CLUSTER_HEADERS, _FILE2_DATA)
+    return file1, file2
+
+
+def test_mmseqs2_success_1_file_new_table(minio_files):
+    user = "someuser"
+    namespace_prefix = f"u_{user}__"
+    file1 = minio_files[0]
+    job_info = {
+        "id": "tstjob1",
+        "namespace_prefix": namespace_prefix,
+        "outputs": [{"file": file1, "crc64nvme": "fake"}],
+    }
+    sparkprov = None
+    try:
+        sparkprov = SparkProvider("test_mmseqs2", user)
+        run_import(sparkprov, job_info, {"deltatable": "mmseqs2_test.mmseqs2_single"})
+
+        spark = sparkprov.spark
+        res_df = spark.sql(f"SELECT * FROM {namespace_prefix}mmseqs2_test.mmseqs2_single")
+        actual = res_df.orderBy("representative", "member").collect()
+        assert_pyspark_rows_almost_equal(actual, _rows(_EXPECTED_FILE1))
+    except Exception:
+        traceback.print_exc()
+        raise
+    finally:
+        if sparkprov:
+            sparkprov.stop()
+        spark_clean = spark_session("test_mmseqs2_helper", user)
+        spark_clean.sql(f"DROP DATABASE IF EXISTS {namespace_prefix}mmseqs2_test CASCADE")
+        spark_clean.stop()
+
+
+def test_mmseqs2_success_2_files_existing_table(minio_files):
+    user = "testuser"
+    namespace_prefix = f"u_{user}__"
+    file1, file2 = minio_files
+    job_info = {
+        "id": "tstjob2",
+        "namespace_prefix": namespace_prefix,
+        "outputs": [
+            {"file": file1, "crc64nvme": "fake"},
+            {"file": f"{get_CTS_output_bucket()}/mmseqs2/sub1/other_file.tsv", "crc64nvme": "fake"},
+            {"file": file2, "crc64nvme": "fake"},
+        ],
+    }
+    spark_setup = spark_session("test_mmseqs2_startup", user)
+    sparkprov = None
+    try:
+        spark_setup.sql(f"CREATE DATABASE IF NOT EXISTS {namespace_prefix}mmseqs2_test")
+        df = spark_setup.createDataFrame(_DB_INIT_DATA, schema=MMSEQS2_CLUSTER_SCHEMA)
+        df.write.mode("overwrite").option("compression", "snappy").format("delta").saveAsTable(
+            f"{namespace_prefix}mmseqs2_test.mmseqs2_clusters"
+        )
+        spark_setup.stop()
+
+        sparkprov = SparkProvider("test_mmseqs2", user)
+        run_import(sparkprov, job_info, {"deltatable": "mmseqs2_test.mmseqs2_clusters"})
+
+        spark = sparkprov.spark
+        res_df = spark.sql(f"SELECT * FROM {namespace_prefix}mmseqs2_test.mmseqs2_clusters")
+        actual = res_df.orderBy("representative", "member", CTS_JOB_ID).collect()
+        assert_pyspark_rows_almost_equal(actual, _rows(_EXPECTED_FULL))
+    except Exception:
+        traceback.print_exc()
+        raise
+    finally:
+        spark_setup.stop()
+        if sparkprov:
+            sparkprov.stop()
+        spark_clean = spark_session("test_mmseqs2_helper", user)
+        spark_clean.sql(f"DROP DATABASE IF EXISTS {namespace_prefix}mmseqs2_test CASCADE")
+        spark_clean.stop()
+
+
+def test_mmseqs2_no_cluster_files_raises(minio_files):
+    user = "someuser"
+    namespace_prefix = f"u_{user}__"
+    job_info = {
+        "id": "tstjob3",
+        "namespace_prefix": namespace_prefix,
+        "outputs": [{"file": f"{get_CTS_output_bucket()}/mmseqs2/sub1/rep_seq.fasta", "crc64nvme": "fake"}],
+    }
+    sparkprov = SparkProvider("test_mmseqs2_err", user)
+    try:
+        with pytest.raises(ValueError, match="No MMseqs2 cluster TSV files found"):
+            run_import(sparkprov, job_info, {"deltatable": "mmseqs2_test.mmseqs2_err"})
+    finally:
+        sparkprov.stop()
+
+
+def test_mmseqs2_no_deltatable_in_metadata_raises(minio_files):
+    user = "someuser"
+    namespace_prefix = f"u_{user}__"
+    file1 = minio_files[0]
+    job_info = {
+        "id": "tstjob4",
+        "namespace_prefix": namespace_prefix,
+        "outputs": [{"file": file1, "crc64nvme": "fake"}],
+    }
+    sparkprov = SparkProvider("test_mmseqs2_meta_err", user)
+    try:
+        with pytest.raises(ValueError, match="deltatable"):
+            run_import(sparkprov, job_info, {})
+    finally:
+        sparkprov.stop()

--- a/test/mmseqs2_test.py
+++ b/test/mmseqs2_test.py
@@ -1,3 +1,5 @@
+import csv
+import io
 import pytest
 import traceback
 from pyspark.sql.types import Row
@@ -12,12 +14,17 @@ from utils.misc import (
     get_CTS_output_bucket,
     get_s3_client,
     set_up_basic_logging,
-    write_tsv_to_s3,
 )
 from utils.spark import spark_session, SparkProvider
 
 
-_CLUSTER_HEADERS = ["representative", "member"]
+def _write_tsv_no_header(s3cli, s3_path, rows):
+    """Write TSV rows to S3 without a header — matches actual MMseqs2 output format."""
+    bucket, key = s3_path.split("/", 1)
+    buf = io.StringIO()
+    csv.writer(buf, delimiter="\t", lineterminator="\n").writerows(rows)
+    buf.seek(0)
+    s3cli.put_object(Bucket=bucket, Key=key, Body=buf.getvalue().encode("utf-8"))
 
 # Initial table state (pre-existing rows from an older job)
 _DB_INIT_DATA = [
@@ -64,8 +71,9 @@ def minio_files():
     file1 = f"{bucket}/mmseqs2/sub1/cluster_results_cluster.tsv"
     file2 = f"{bucket}/mmseqs2/sub2/cluster_results_cluster.tsv"
     s3cli = get_s3_client()
-    write_tsv_to_s3(s3cli, file1, _CLUSTER_HEADERS, _FILE1_DATA)
-    write_tsv_to_s3(s3cli, file2, _CLUSTER_HEADERS, _FILE2_DATA)
+    # MMseqs2 cluster TSV has no header — write raw rows only
+    _write_tsv_no_header(s3cli, file1, _FILE1_DATA)
+    _write_tsv_no_header(s3cli, file2, _FILE2_DATA)
     return file1, file2
 
 

--- a/test/mmseqs2_test.py
+++ b/test/mmseqs2_test.py
@@ -1,13 +1,14 @@
 import csv
 import io
-import pytest
 import traceback
+
+import pytest
 from pyspark.sql.types import Row
 
 from cdmeventimporters.mmseqs2 import (
-    run_import,
-    MMSEQS2_CLUSTER_SCHEMA,
     CTS_JOB_ID,
+    MMSEQS2_CLUSTER_SCHEMA,
+    run_import,
 )
 from utils.misc import (
     assert_pyspark_rows_almost_equal,
@@ -15,16 +16,29 @@ from utils.misc import (
     get_s3_client,
     set_up_basic_logging,
 )
-from utils.spark import spark_session, SparkProvider
+from utils.spark import SparkProvider, spark_session
 
 
 def _write_tsv_no_header(s3cli, s3_path, rows):
-    """Write TSV rows to S3 without a header — matches actual MMseqs2 output format."""
+    """Write TSV rows to S3 without a header - matches actual MMseqs2 output format."""
     bucket, key = s3_path.split("/", 1)
     buf = io.StringIO()
     csv.writer(buf, delimiter="\t", lineterminator="\n").writerows(rows)
     buf.seek(0)
     s3cli.put_object(Bucket=bucket, Key=key, Body=buf.getvalue().encode("utf-8"))
+
+
+def _drop_namespace(spark, namespace: str):
+    """Drop every table in the namespace, then the namespace itself.
+
+    Same pattern as checkm2_test: Polaris rejects `DROP NAMESPACE ... CASCADE`, so the
+    tables have to come out one at a time before the namespace. `PURGE` removes data
+    + metadata files from S3 so warehouse orphans don't accumulate across test runs.
+    """
+    for tbl in spark.sql(f"SHOW TABLES IN {namespace}").collect():
+        spark.sql(f"DROP TABLE IF EXISTS {namespace}.{tbl['tableName']} PURGE")
+    spark.sql(f"DROP NAMESPACE IF EXISTS {namespace}")
+
 
 # Initial table state (pre-existing rows from an older job)
 _DB_INIT_DATA = [
@@ -71,7 +85,7 @@ def minio_files():
     file1 = f"{bucket}/mmseqs2/sub1/cluster_results_cluster.tsv"
     file2 = f"{bucket}/mmseqs2/sub2/cluster_results_cluster.tsv"
     s3cli = get_s3_client()
-    # MMseqs2 cluster TSV has no header — write raw rows only
+    # MMseqs2 cluster TSV has no header - write raw rows only
     _write_tsv_no_header(s3cli, file1, _FILE1_DATA)
     _write_tsv_no_header(s3cli, file2, _FILE2_DATA)
     return file1, file2
@@ -79,40 +93,43 @@ def minio_files():
 
 def test_mmseqs2_success_1_file_new_table(minio_files):
     user = "someuser"
-    namespace_prefix = f"u_{user}__"
+    namespace = "mmseqs2_test"
+    table = f"{namespace}.mmseqs2_single"
     file1 = minio_files[0]
     job_info = {
         "id": "tstjob1",
-        "namespace_prefix": namespace_prefix,
+        # Empty under Polaris/Iceberg; preserved as the back-compat contract.
+        "namespace_prefix": "",
         "outputs": [{"file": file1, "crc64nvme": "fake"}],
     }
     sparkprov = None
     try:
         sparkprov = SparkProvider("test_mmseqs2", user)
-        run_import(sparkprov, job_info, {"deltatable": "mmseqs2_test.mmseqs2_single"})
+        run_import(sparkprov, job_info, {"table": table})
 
         spark = sparkprov.spark
-        res_df = spark.sql(f"SELECT * FROM {namespace_prefix}mmseqs2_test.mmseqs2_single")
+        res_df = spark.sql(f"SELECT * FROM {table}")
         actual = res_df.orderBy("representative", "member").collect()
         assert_pyspark_rows_almost_equal(actual, _rows(_EXPECTED_FILE1))
     except Exception:
-        traceback.print_exc()
+        traceback.print_exc()  # can get shadowed by exception in the finally block
         raise
     finally:
         if sparkprov:
             sparkprov.stop()
         spark_clean = spark_session("test_mmseqs2_helper", user)
-        spark_clean.sql(f"DROP DATABASE IF EXISTS {namespace_prefix}mmseqs2_test CASCADE")
+        _drop_namespace(spark_clean, namespace)
         spark_clean.stop()
 
 
 def test_mmseqs2_success_2_files_existing_table(minio_files):
     user = "testuser"
-    namespace_prefix = f"u_{user}__"
+    namespace = "mmseqs2_test"
+    table = f"{namespace}.mmseqs2_clusters"
     file1, file2 = minio_files
     job_info = {
         "id": "tstjob2",
-        "namespace_prefix": namespace_prefix,
+        "namespace_prefix": "",
         "outputs": [
             {"file": file1, "crc64nvme": "fake"},
             {"file": f"{get_CTS_output_bucket()}/mmseqs2/sub1/other_file.tsv", "crc64nvme": "fake"},
@@ -122,18 +139,16 @@ def test_mmseqs2_success_2_files_existing_table(minio_files):
     spark_setup = spark_session("test_mmseqs2_startup", user)
     sparkprov = None
     try:
-        spark_setup.sql(f"CREATE DATABASE IF NOT EXISTS {namespace_prefix}mmseqs2_test")
+        spark_setup.sql(f"CREATE NAMESPACE IF NOT EXISTS {namespace}")
         df = spark_setup.createDataFrame(_DB_INIT_DATA, schema=MMSEQS2_CLUSTER_SCHEMA)
-        df.write.mode("overwrite").option("compression", "snappy").format("delta").saveAsTable(
-            f"{namespace_prefix}mmseqs2_test.mmseqs2_clusters"
-        )
+        df.writeTo(table).using("iceberg").create()
         spark_setup.stop()
 
         sparkprov = SparkProvider("test_mmseqs2", user)
-        run_import(sparkprov, job_info, {"deltatable": "mmseqs2_test.mmseqs2_clusters"})
+        run_import(sparkprov, job_info, {"table": table})
 
         spark = sparkprov.spark
-        res_df = spark.sql(f"SELECT * FROM {namespace_prefix}mmseqs2_test.mmseqs2_clusters")
+        res_df = spark.sql(f"SELECT * FROM {table}")
         actual = res_df.orderBy("representative", "member", CTS_JOB_ID).collect()
         assert_pyspark_rows_almost_equal(actual, _rows(_EXPECTED_FULL))
     except Exception:
@@ -144,38 +159,36 @@ def test_mmseqs2_success_2_files_existing_table(minio_files):
         if sparkprov:
             sparkprov.stop()
         spark_clean = spark_session("test_mmseqs2_helper", user)
-        spark_clean.sql(f"DROP DATABASE IF EXISTS {namespace_prefix}mmseqs2_test CASCADE")
+        _drop_namespace(spark_clean, namespace)
         spark_clean.stop()
 
 
 def test_mmseqs2_no_cluster_files_raises(minio_files):
     user = "someuser"
-    namespace_prefix = f"u_{user}__"
     job_info = {
         "id": "tstjob3",
-        "namespace_prefix": namespace_prefix,
+        "namespace_prefix": "",
         "outputs": [{"file": f"{get_CTS_output_bucket()}/mmseqs2/sub1/rep_seq.fasta", "crc64nvme": "fake"}],
     }
     sparkprov = SparkProvider("test_mmseqs2_err", user)
     try:
         with pytest.raises(ValueError, match="No MMseqs2 cluster TSV files found"):
-            run_import(sparkprov, job_info, {"deltatable": "mmseqs2_test.mmseqs2_err"})
+            run_import(sparkprov, job_info, {"table": "mmseqs2_test.mmseqs2_err"})
     finally:
         sparkprov.stop()
 
 
-def test_mmseqs2_no_deltatable_in_metadata_raises(minio_files):
+def test_mmseqs2_no_table_in_metadata_raises(minio_files):
     user = "someuser"
-    namespace_prefix = f"u_{user}__"
     file1 = minio_files[0]
     job_info = {
         "id": "tstjob4",
-        "namespace_prefix": namespace_prefix,
+        "namespace_prefix": "",
         "outputs": [{"file": file1, "crc64nvme": "fake"}],
     }
     sparkprov = SparkProvider("test_mmseqs2_meta_err", user)
     try:
-        with pytest.raises(ValueError, match="deltatable"):
+        with pytest.raises(ValueError, match="'table' key"):
             run_import(sparkprov, job_info, {})
     finally:
         sparkprov.stop()


### PR DESCRIPTION
## Summary

- Adds `cdmeventimporters/mmseqs2.py` — imports `cluster_results_cluster.tsv` from CTS jobs running `ghcr.io/kbaseincubator/cdm_mmseqs2` into a Delta Lake table (`autoimport.mmseqs2_clusters`)
- Adds `cdmeventimporters/mmseqs2.yaml` — wires the importer to the image
- Adds `test/mmseqs2_test.py` — 4 tests covering new table, existing table, missing file, missing metadata

## Design notes

- Output schema: `representative (str)`, `member (str)`, `cts_job_id (str)`
- Dedup key includes `cts_job_id` so results from different jobs coexist in the table; reprocessed events for the same job are idempotent
- Only `cluster_results_cluster.tsv` files are imported; `.fasta` outputs are ignored

## Test plan

- [ ] `test_mmseqs2_success_1_file_new_table` — imports into a fresh table, verifies rows
- [ ] `test_mmseqs2_success_2_files_existing_table` — imports into pre-populated table, verifies old rows preserved and new rows added
- [ ] `test_mmseqs2_no_cluster_files_raises` — raises `ValueError` when no cluster TSV in outputs
- [ ] `test_mmseqs2_no_deltatable_in_metadata_raises` — raises `ValueError` when metadata missing `deltatable` key

🤖 Generated with [Claude Code](https://claude.ai/claude-code)