### PR TITLE
Add KofamScan importer

### DIFF
--- a/cdmeventimporters/kofamscan.py
+++ b/cdmeventimporters/kofamscan.py
@@ -1,0 +1,117 @@
+"""
+Importer for KofamScan KO HMM annotations.
+
+Stores only significant hits (rows with `*` in the leading column, meaning
+`score >= per-KO threshold`). Each gene can have multiple significant KO hits;
+one row per (gene, KO).
+"""
+
+import logging
+from typing import Any
+
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import col, lit
+from pyspark.sql.types import DoubleType, FloatType, StringType, StructField, StructType
+
+from cdmeventimporters import utilities
+
+
+CTS_JOB_ID = "cts_job_id"
+_ANNOTATIONS_TSV = "annotations.tsv"
+
+
+KOFAMSCAN_DB_SCHEMA = StructType([
+    StructField("gene_name", StringType()),
+    StructField("KO", StringType()),
+    StructField(CTS_JOB_ID, StringType()),
+    StructField("threshold", FloatType()),
+    StructField("score", FloatType()),
+    StructField("evalue", DoubleType()),
+    StructField("KO_definition", StringType()),
+])
+
+
+def _ensure_table(spark: SparkSession, logr: logging.Logger, full_tablename: str):
+    namespace = full_tablename.rsplit(".", 1)[0]
+    spark.sql(f"CREATE NAMESPACE IF NOT EXISTS {namespace}")
+    if not spark.catalog.tableExists(full_tablename):
+        logr.info(f"Creating new Iceberg table {full_tablename}")
+        empty_df = spark.createDataFrame([], KOFAMSCAN_DB_SCHEMA)
+        empty_df.writeTo(full_tablename).using("iceberg").create()
+
+
+def run_import(get_spark, job_info: dict[str, Any], metadata: dict[str, Any]):
+    """
+    Run the KofamScan import.
+
+    Reads each `annotations.tsv` from the job's outputs and writes the significant KO
+    hits into an Iceberg table keyed on (gene_name, KO, cts_job_id). Filter is applied
+    inside this importer: rows whose first column is not `*` are dropped (non-significant
+    HMM hits below the KO-specific score threshold).
+
+    KofamScan output format (one file per genome, tab-separated):
+        line 0  : `#  gene name  KO  thrshld  score  E-value  "KO definition"`
+        line 1  : `#  ---------  ------  ...` (separator row, naturally filtered out by
+                  the significance check below)
+        line 2+ : data rows, with `*` in column 0 for significant hits
+
+    Assumptions
+        * The schema is uniform across kofamscan versions.
+        * Multiple significant hits per gene are valid (different KOs can hit; we keep
+          all of them).
+        * Dedup key is (gene_name, KO, cts_job_id) so results from different jobs coexist
+          and reprocessed events for the same job do not insert duplicates.
+
+    get_spark - a function to get a spark session. Has a single keyword argument,
+        executor_cores, that sets the cores per spark executor for the job. Defaults to 1.
+    job_info - information about the completed CTS job, in particular the job ID and
+        output files.
+    metadata - importer metadata from the YAML config (must include 'table').
+    """
+    logr = logging.getLogger(__name__)
+
+    job_id = job_info["id"]
+    output_files = [f["file"] for f in job_info["outputs"] if f["file"].endswith(_ANNOTATIONS_TSV)]
+    if not output_files:
+        raise ValueError("No KofamScan annotations.tsv files found in job outputs")
+    logr.info(f"Importing {len(output_files)} KofamScan annotation file(s) from CTS job {job_id}")
+
+    tablename = metadata.get("table")
+    if not tablename:
+        raise ValueError(
+            "Expected a 'table' key in the importer metadata with the namespace.table as the value"
+        )
+    # The Spark session is wired to the user's Iceberg catalog as the default catalog,
+    # so a `<namespace>.<table>` reference resolves into that catalog automatically.
+
+    spark = get_spark()
+    _ensure_table(spark, logr, tablename)
+
+    # Read with header=True (so Spark consumes line 0 as column names), then rename
+    # positionally with toDF so we sidestep the `#` and `gene name` special-character
+    # issues. The separator row (line 1 in the source file) becomes data row 0 here;
+    # the significance filter below excludes it because its first column is `#---------`
+    # rather than `*`.
+    raw = spark.read.option("header", True).option("sep", "\t").csv(
+        [f"s3a://{f}" for f in output_files]
+    ).toDF("significant", "gene_name", "KO", "threshold", "score", "evalue", "KO_definition")
+
+    df = (raw
+          .filter(col("significant") == "*")
+          .withColumn(CTS_JOB_ID, lit(job_id)))
+
+    columns = [
+        col(field.name).cast(field.dataType).alias(field.name)
+        for field in KOFAMSCAN_DB_SCHEMA
+    ]
+    df = df.select(*columns)
+
+    utilities.merge_spark_df_to_table(
+        spark,
+        df,
+        tablename,
+        "target.gene_name = source.gene_name "
+        "AND target.KO = source.KO "
+        "AND target.cts_job_id = source.cts_job_id",
+        update=False,
+    )

--- a/cdmeventimporters/kofamscan.yaml
+++ b/cdmeventimporters/kofamscan.yaml
@@ -1,0 +1,13 @@
+# The name of the importer. Informational purposes only.
+name: kofamscan
+# The location of the importer module containing the `run_import` method.
+py_module: cdmeventimporters.kofamscan
+# The image associated with the importer. This importer will run when a CTS job completes
+# with this image.
+image: ghcr.io/kbaseincubator/cdm_kofamscan
+# Metadata for the importer.
+importer_meta:
+    # The table where KofamScan KO HMM hits should be stored, in `<namespace>.<table>` format.
+    # The Spark session resolves this against the user's Iceberg catalog (the default
+    # catalog `my`), so no per-user prefix is required.
+    table: autoimport.kofamscan

--- a/test/kofamscan_test.py
+++ b/test/kofamscan_test.py
@@ -1,0 +1,200 @@
+import io
+import traceback
+
+import pytest
+from pyspark.sql.types import Row
+
+from cdmeventimporters.kofamscan import (
+    CTS_JOB_ID,
+    KOFAMSCAN_DB_SCHEMA,
+    run_import,
+)
+from utils.misc import (
+    assert_pyspark_rows_almost_equal,
+    get_CTS_output_bucket,
+    get_s3_client,
+    set_up_basic_logging,
+)
+from utils.spark import SparkProvider, spark_session
+
+
+# Header + separator that real kofamscan output emits.
+_HEADER = '#\tgene name\tKO\tthrshld\tscore\tE-value\t"KO definition"'
+_SEPARATOR = '#\t---------\t------\t-------\t------\t---------\t-------------'
+
+
+def _write_kofamscan_tsv(s3cli, s3_path, rows):
+    """Write a kofamscan annotations.tsv to S3.
+
+    Each row is a tuple of (significant_marker, gene_name, KO, threshold, score, evalue,
+    KO_definition). `significant_marker` is "*" for significant hits, "" otherwise.
+    """
+    bucket, key = s3_path.split("/", 1)
+    buf = io.StringIO()
+    buf.write(_HEADER + "\n")
+    buf.write(_SEPARATOR + "\n")
+    for r in rows:
+        sig, gene, ko, thr, sc, ev, defn = r
+        # Quote the definition as kofamscan does (matches the real output format).
+        buf.write(f"{sig}\t{gene}\t{ko}\t{thr}\t{sc}\t{ev}\t\"{defn}\"\n")
+    s3cli.put_object(Bucket=bucket, Key=key, Body=buf.getvalue().encode("utf-8"))
+
+
+def _drop_namespace(spark, namespace: str):
+    """See checkm2_test._drop_namespace for the Polaris/Iceberg rationale."""
+    for tbl in spark.sql(f"SHOW TABLES IN {namespace}").collect():
+        spark.sql(f"DROP TABLE IF EXISTS {namespace}.{tbl['tableName']} PURGE")
+    spark.sql(f"DROP NAMESPACE IF EXISTS {namespace}")
+
+
+# Pre-existing rows in the target table (older job)
+_DB_INIT_DATA = [
+    ("AE017199.1_99", "K00001", "old_job", 100.0, 250.0, 1e-50, "alcohol dehydrogenase"),
+]
+
+# File 1: two significant hits + one non-significant (which should be dropped by the
+# importer's filter)
+_FILE1_DATA = [
+    ("*", "AE017199.1_1", "K19091",  38.33, 106.1, 1.2e-31, "CRISPR-associated endoribonuclease Cas6"),
+    ("*", "AE017199.1_2", "K03724", 281.63, 744.2, 1.2e-224, "ATP-dependent helicase Lhr"),
+    ("",  "AE017199.1_2", "K06877", 271.90, 209.9, 1.9e-63,  "DEAD/DEAH box helicase domain"),
+]
+
+# File 2: one significant hit
+_FILE2_DATA = [
+    ("*", "AE017199.1_5", "K02338", 200.0, 500.0, 1e-100, "DNA polymerase III subunit beta"),
+]
+
+_EXPECTED_FILE1 = [
+    ("AE017199.1_1", "K19091", "tstjob1",  38.33, 106.1, 1.2e-31, "CRISPR-associated endoribonuclease Cas6"),
+    ("AE017199.1_2", "K03724", "tstjob1", 281.63, 744.2, 1.2e-224, "ATP-dependent helicase Lhr"),
+]
+
+_EXPECTED_FULL = [
+    ("AE017199.1_1",  "K19091", "tstjob2",  38.33, 106.1, 1.2e-31,  "CRISPR-associated endoribonuclease Cas6"),
+    ("AE017199.1_2",  "K03724", "tstjob2", 281.63, 744.2, 1.2e-224, "ATP-dependent helicase Lhr"),
+    ("AE017199.1_5",  "K02338", "tstjob2", 200.0,  500.0, 1e-100,   "DNA polymerase III subunit beta"),
+    ("AE017199.1_99", "K00001", "old_job", 100.0,  250.0, 1e-50,    "alcohol dehydrogenase"),
+]
+
+
+set_up_basic_logging(force=False)
+
+
+def _rows(data):
+    fields = [f.name for f in KOFAMSCAN_DB_SCHEMA]
+    # Field order in schema: gene_name, KO, cts_job_id, threshold, score, evalue, KO_definition
+    return [Row(**dict(zip(fields, r))) for r in data]
+
+
+@pytest.fixture(scope="module")
+def minio_files():
+    bucket = get_CTS_output_bucket()
+    file1 = f"{bucket}/kofamscan/sub1/annotations.tsv"
+    file2 = f"{bucket}/kofamscan/sub2/annotations.tsv"
+    s3cli = get_s3_client()
+    _write_kofamscan_tsv(s3cli, file1, _FILE1_DATA)
+    _write_kofamscan_tsv(s3cli, file2, _FILE2_DATA)
+    return file1, file2
+
+
+def test_kofamscan_success_1_file_new_table(minio_files):
+    user = "someuser"
+    namespace = "kofamscan_test"
+    table = f"{namespace}.kofamscan_single"
+    file1 = minio_files[0]
+    job_info = {
+        "id": "tstjob1",
+        "namespace_prefix": "",
+        "outputs": [{"file": file1, "crc64nvme": "fake"}],
+    }
+    sparkprov = None
+    try:
+        sparkprov = SparkProvider("test_kofamscan", user)
+        run_import(sparkprov, job_info, {"table": table})
+
+        spark = sparkprov.spark
+        res_df = spark.sql(f"SELECT * FROM {table}")
+        actual = res_df.orderBy("gene_name", "KO").collect()
+        assert_pyspark_rows_almost_equal(actual, _rows(_EXPECTED_FILE1))
+    except Exception:
+        traceback.print_exc()
+        raise
+    finally:
+        if sparkprov:
+            sparkprov.stop()
+        spark_clean = spark_session("test_kofamscan_helper", user)
+        _drop_namespace(spark_clean, namespace)
+        spark_clean.stop()
+
+
+def test_kofamscan_success_2_files_existing_table(minio_files):
+    user = "testuser"
+    namespace = "kofamscan_test"
+    table = f"{namespace}.kofamscan_hits"
+    file1, file2 = minio_files
+    job_info = {
+        "id": "tstjob2",
+        "namespace_prefix": "",
+        "outputs": [
+            {"file": file1, "crc64nvme": "fake"},
+            {"file": f"{get_CTS_output_bucket()}/kofamscan/sub1/other.tsv", "crc64nvme": "fake"},
+            {"file": file2, "crc64nvme": "fake"},
+        ],
+    }
+    spark_setup = spark_session("test_kofamscan_startup", user)
+    sparkprov = None
+    try:
+        spark_setup.sql(f"CREATE NAMESPACE IF NOT EXISTS {namespace}")
+        df = spark_setup.createDataFrame(_DB_INIT_DATA, schema=KOFAMSCAN_DB_SCHEMA)
+        df.writeTo(table).using("iceberg").create()
+        spark_setup.stop()
+
+        sparkprov = SparkProvider("test_kofamscan", user)
+        run_import(sparkprov, job_info, {"table": table})
+
+        spark = sparkprov.spark
+        res_df = spark.sql(f"SELECT * FROM {table}")
+        actual = res_df.orderBy("gene_name", "KO", CTS_JOB_ID).collect()
+        assert_pyspark_rows_almost_equal(actual, _rows(_EXPECTED_FULL))
+    except Exception:
+        traceback.print_exc()
+        raise
+    finally:
+        spark_setup.stop()
+        if sparkprov:
+            sparkprov.stop()
+        spark_clean = spark_session("test_kofamscan_helper", user)
+        _drop_namespace(spark_clean, namespace)
+        spark_clean.stop()
+
+
+def test_kofamscan_no_annotation_files_raises(minio_files):
+    user = "someuser"
+    job_info = {
+        "id": "tstjob3",
+        "namespace_prefix": "",
+        "outputs": [{"file": f"{get_CTS_output_bucket()}/kofamscan/sub1/other.tsv", "crc64nvme": "fake"}],
+    }
+    sparkprov = SparkProvider("test_kofamscan_err", user)
+    try:
+        with pytest.raises(ValueError, match="No KofamScan annotations.tsv files found"):
+            run_import(sparkprov, job_info, {"table": "kofamscan_test.kofamscan_err"})
+    finally:
+        sparkprov.stop()
+
+
+def test_kofamscan_no_table_in_metadata_raises(minio_files):
+    user = "someuser"
+    file1 = minio_files[0]
+    job_info = {
+        "id": "tstjob4",
+        "namespace_prefix": "",
+        "outputs": [{"file": file1, "crc64nvme": "fake"}],
+    }
+    sparkprov = SparkProvider("test_kofamscan_meta_err", user)
+    try:
+        with pytest.raises(ValueError, match="'table' key"):
+            run_import(sparkprov, job_info, {})
+    finally:
+        sparkprov.stop()


### PR DESCRIPTION
## Summary

Adds an importer for `cdm_kofamscan` CTS job outputs, following the post-#40 Iceberg-via-Polaris pattern established by the checkm2 importer. Mirrors the structural choices in [#35](https://github.com/kbase/cdm-spark-events-importers/pull/35) (the rebased mmseqs2 PR). Tracked by the [importer roadmap issue #41](https://github.com/kbase/cdm-spark-events-importers/issues/41).

## Schema

One Iceberg table `autoimport.kofamscan` (configurable via the YAML metadata), keyed on `(gene_name, KO, cts_job_id)`:

| Column | Type | Notes |
|---|---|---|
| `gene_name` | string | Input protein locus tag (e.g. `AE017199.1_1`) |
| `KO` | string | KEGG Orthology id (e.g. `K19091`) |
| `cts_job_id` | string | Source CTS job id (provenance) |
| `threshold` | float | Per-KO score threshold from the HMM model |
| `score` | float | HMM bit score for this hit |
| `evalue` | double | HMM E-value (Double, not Float, so values like `1.2e-224` round-trip) |
| `KO_definition` | string | Human-readable KO name + EC numbers |

## Design choices

- **Significant hits only.** KofamScan emits both significant (`*` in column 0) and non-significant hits in the same TSV. Non-significant hits inflate the table ~50x and are below-threshold noise downstream consumers don't want. The importer filters to significant rows only. The separator row at line 1 of the source file (column 0 == `#---------`) is dropped by the same filter.
- **Dedup on `(gene_name, KO, cts_job_id)` with `update=False`.** Different jobs coexist (rerunning kofamscan on a new genome adds rows); reprocessed events for the same job are idempotent. Same pattern as mmseqs2 (also many-rows-per-input).
- **Positional column rename via `toDF(...)`.** KofamScan's TSV header uses `#` and `gene name` as column names. Spark CSV reader handles them, but downstream `col(...)` and SQL backtick-escaping is ugly. We let Spark read the header (`header=True`) and immediately rename positionally to clean Python identifiers.

## Tests

`test/kofamscan_test.py` covers:

- Single-file import into a fresh table (writes header + separator + 2 significant + 1 non-significant row; verifies only the 2 significant rows land)
- Two-file import into a pre-existing table with old-job rows (verifies coexistence on `cts_job_id`)
- Missing-input-files error (no `annotations.tsv` in job outputs)
- Missing-metadata error (no `table` key)

Same `SparkProvider` + `_drop_namespace` test pattern as the post-#40 checkm2 and mmseqs2 tests.

## Test plan

- [ ] CI runs the new `kofamscan_test.py` against the Polaris-backed Spark session and all 4 tests pass
- [ ] Manual sanity check that the importer YAML metadata is picked up by CSEP (the event processor) on a real `cdm_kofamscan` CTS job

🤖 Generated with [Claude Code](https://claude.com/claude-code)